### PR TITLE
feature : [ADD]UpdateTutorInfo

### DIFF
--- a/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/controller/TutorController.java
+++ b/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/controller/TutorController.java
@@ -3,6 +3,8 @@ package com.sparta.hh99springlv3.domain.tutor.controller;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto.CreateTutorRequestDto;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.ReadTutorResponseDto;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.CreateTutorResponseDto;
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.UpdateTutorResponseDto;
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto.UpdateTutorRequestDto;
 import com.sparta.hh99springlv3.domain.tutor.service.TutorService;
 import com.sparta.hh99springlv3.global.jwt.JwtUtil;
 import jakarta.validation.Valid;
@@ -23,5 +25,10 @@ public class TutorController {
     @GetMapping("/{tutorId}")
     public ReadTutorResponseDto readTutorInfo(@PathVariable Long tutorId, @CookieValue(JwtUtil.AUTHORIZATION_HEADER) String tokenValue){
         return tutorService.readTutorInfo(tutorId, tokenValue);
+    }
+
+    @PutMapping("/{tutorId}")
+    public UpdateTutorResponseDto updateTutorInfo(@PathVariable Long tutorId, @RequestBody UpdateTutorRequestDto requestDto,@CookieValue(JwtUtil.AUTHORIZATION_HEADER) String tokenValue){
+        return tutorService.updateTutorInfo(tutorId, requestDto, tokenValue);
     }
 }

--- a/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/dto/TutorRequestDto.java
+++ b/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/dto/TutorRequestDto.java
@@ -25,5 +25,12 @@ public class TutorRequestDto {
                     .build();
         }
     }
+    @Getter
+    public static class UpdateTutorRequestDto{
+        private String career;
+        private String company;
+        private String phoneNumber;
+        private String tuIntroduce;
+    }
 
 }

--- a/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/dto/TutorResponseDto.java
+++ b/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/dto/TutorResponseDto.java
@@ -38,4 +38,20 @@ public class TutorResponseDto {
         }
 
     }
+    @Getter
+    public static class UpdateTutorResponseDto{
+        private String tutorName;
+        private String career;
+        private String company;
+        private String phoneNumber;
+        private String tuIntroduce;
+
+        public UpdateTutorResponseDto(Tutor tutor){
+            this.tutorName = tutor.getTutorName();
+            this.career = tutor.getCareer();
+            this.company = tutor.getCompany();
+            this.phoneNumber = tutor.getPhoneNumber();
+            this.tuIntroduce = tutor.getTuIntroduce();
+        }
+    }
 }

--- a/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/entity/Tutor.java
+++ b/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/entity/Tutor.java
@@ -1,5 +1,6 @@
 package com.sparta.hh99springlv3.domain.tutor.entity;
 
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto.UpdateTutorRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,4 +24,11 @@ public class Tutor {
     @Column(nullable = false)
     private String phoneNumber;
     private String tuIntroduce;
+
+    public void updateTutorInfo(UpdateTutorRequestDto tutor){
+        this.career = tutor.getCareer();
+        this.company = tutor.getCompany();
+        this.phoneNumber = tutor.getPhoneNumber();
+        this.tuIntroduce = tutor.getTuIntroduce();
+    }
 }

--- a/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/service/TutorService.java
+++ b/HH99SpringLv3/src/main/java/com/sparta/hh99springlv3/domain/tutor/service/TutorService.java
@@ -1,8 +1,10 @@
 package com.sparta.hh99springlv3.domain.tutor.service;
 
 import com.sparta.hh99springlv3.domain.admin.entity.AuthEnum;
-import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto;
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto.UpdateTutorRequestDto;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorRequestDto.CreateTutorRequestDto;
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto;
+import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.UpdateTutorResponseDto;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.ReadTutorResponseDto;
 import com.sparta.hh99springlv3.domain.tutor.dto.TutorResponseDto.CreateTutorResponseDto;
 import com.sparta.hh99springlv3.domain.tutor.entity.Tutor;
@@ -12,6 +14,7 @@ import com.sparta.hh99springlv3.global.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.sparta.hh99springlv3.global.handler.exception.ErrorCode.NOT_FOUND_TUTOR_ID;
 import static com.sparta.hh99springlv3.global.handler.exception.ErrorCode.UNAUTHORIZED_ADMIN;
@@ -34,8 +37,7 @@ public class TutorService {
         Claims info = jwtUtil.getUserInfoFromToken(token);
         String authority = (String) info.get(JwtUtil.AUTHORIZATION_KEY);
         if(!(AuthEnum.valueOf(authority)).equals(AuthEnum.MANAGER)){
-             isMANAGER=false;
-             return isMANAGER;
+             return !isMANAGER;
         }
         return isMANAGER;
     }
@@ -46,6 +48,7 @@ public class TutorService {
         Tutor tutor = tutorRepository.save(requestDto.toEntity());
         return new CreateTutorResponseDto(tutor);
     }
+    @Transactional(readOnly = true)
     public ReadTutorResponseDto readTutorInfo(Long tutorId, String tokenValue){
         if(!checkAuthority(tokenValue)){
             throw new CustomApiException(UNAUTHORIZED_ADMIN.getMessage());
@@ -54,5 +57,17 @@ public class TutorService {
                 .orElseThrow(() -> new CustomApiException(NOT_FOUND_TUTOR_ID.getMessage()));
 
         return new ReadTutorResponseDto(tutor);
+    }
+
+    @Transactional
+    public UpdateTutorResponseDto updateTutorInfo(long tutorId,UpdateTutorRequestDto requestDto, String tokenValue){
+        if(!checkAuthority(tokenValue)){
+            throw new CustomApiException(UNAUTHORIZED_ADMIN.getMessage());
+        }
+        Tutor tutor = tutorRepository.findById(tutorId)
+                .orElseThrow(() -> new CustomApiException(NOT_FOUND_TUTOR_ID.getMessage()));
+
+        tutor.updateTutorInfo(requestDto);
+        return new UpdateTutorResponseDto(tutor);
     }
 }


### PR DESCRIPTION
#4 
- 선택한 강사의 경력, 회사, 전화번호, 소개를 수정할 수 있습니다.
- 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
- MANAGER 권한을 가진 관리자만 강사 정보 수정이 가능합니다.
- 수정된 강사의 정보를 반환 받아 확인할 수 있습니다.